### PR TITLE
use proper naming conventions for camera / various warning fixes

### DIFF
--- a/src/base/camera_app.cpp
+++ b/src/base/camera_app.cpp
@@ -27,7 +27,7 @@ void CameraApp::run() {
 
     while(mMainLoop) {
       mLastFrame = mCurrentFrame;
-      mCurrentFrame = SDL_GetTicks()*0.001f;
+      mCurrentFrame = (float)SDL_GetTicks() * 0.001f;
       mDeltaTime = mCurrentFrame - mLastFrame;
 
       processInput();
@@ -45,11 +45,11 @@ void CameraApp::setUpScene() {
 void CameraApp::mainLoopBody() {
   // if last seconds digit changed during current frame, print coords
   if(floor(mLastFrame)-floor(mCurrentFrame)!=0) {
-    std::cout << "Camera pos: " << mCamera.Position.x
-      << " " << mCamera.Position.y
-      << " " << mCamera.Position.z << std::endl;
-    std::cout << "pitch: " << mCamera.Pitch
-      << ", yaw: " << mCamera.Yaw << std::endl;
+    std::cout << "Camera pos: " << mCamera.mPosition.x
+      << " " << mCamera.mPosition.y
+      << " " << mCamera.mPosition.z << std::endl;
+    std::cout << "pitch: " << mCamera.mPitch
+      << ", yaw: " << mCamera.mYaw << std::endl;
   }
 }
 
@@ -65,16 +65,16 @@ void CameraApp::processInput() {
     } else if(e.type == SDL_KEYDOWN) {
       switch(e.key.keysym.sym) {
         case SDLK_w:
-          mCamera.ProcessKeyboard(FORWARD, mDeltaTime);
+          mCamera.processKeyboard(FORWARD, mDeltaTime);
           break;
         case SDLK_s:
-          mCamera.ProcessKeyboard(BACKWARD, mDeltaTime);
+          mCamera.processKeyboard(BACKWARD, mDeltaTime);
           break;
         case SDLK_a:
-          mCamera.ProcessKeyboard(LEFT, mDeltaTime);
+          mCamera.processKeyboard(LEFT, mDeltaTime);
           break;
         case SDLK_d:
-          mCamera.ProcessKeyboard(RIGHT, mDeltaTime);
+          mCamera.processKeyboard(RIGHT, mDeltaTime);
           break;
         default:
           break;
@@ -87,10 +87,10 @@ void CameraApp::mouseCallback(SDL_Event &e) {
   if(mFirstMouse) {
     mFirstMouse = false;
   } else {
-    mCamera.ProcessMouseMovement(e.motion.xrel, -e.motion.yrel);
+    mCamera.processMouseMovement((float)e.motion.xrel, (float)-e.motion.yrel);
   } 
 }
 
 void CameraApp::scrollCallback(SDL_Event &e) {
-  mCamera.ProcessMouseScroll(e.wheel.y);
+  mCamera.processMouseScroll((float)e.wheel.y);
 }

--- a/src/base/camera_app.hpp
+++ b/src/base/camera_app.hpp
@@ -24,9 +24,9 @@ class CameraApp : public App {
     virtual void setUpScene();
     virtual void mainLoopBody();
 
-    double mDeltaTime = 0.0;
-    double mLastFrame = 0.0;
-    double mCurrentFrame = 0.0;
+    float mDeltaTime = 0.0;
+    float mLastFrame = 0.0;
+    float mCurrentFrame = 0.0;
 
     Camera mCamera;
   private:

--- a/src/parallax_mapping/parallax_mapping.cpp
+++ b/src/parallax_mapping/parallax_mapping.cpp
@@ -51,7 +51,7 @@ void ParallaxApp::mainLoopBody() {
   glViewport(0, 0, mWindowWidth, mWindowHeight);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-  mProjection = glm::perspective(glm::radians(mCamera.Zoom),
+  mProjection = glm::perspective(glm::radians(mCamera.mZoom),
       (float)mWindowWidth / (float)mWindowHeight, 0.1f, 100.0f);
   mView = mCamera.GetViewMatrix();
 
@@ -62,7 +62,7 @@ void ParallaxApp::mainLoopBody() {
   mParallaxMappingShader.setMat4("view", mView);
   mParallaxMappingShader.setMat4("projection", mProjection);
   mParallaxMappingShader.setInt("diffuse", 0);
-  mParallaxMappingShader.setVec3("cameraPosition", mCamera.Position);
+  mParallaxMappingShader.setVec3("cameraPosition", mCamera.mPosition);
   mParallaxMappingShader.setVec3("lightPosition", lightPosition);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, mDiffuseTexture);

--- a/src/pbr/pbr.cpp
+++ b/src/pbr/pbr.cpp
@@ -119,8 +119,8 @@ void PBRApp::buildPrefilteredEnvMap() {
   unsigned int maxMipLevels = 4;
   for (unsigned int mip = 0; mip < maxMipLevels; mip++) {
     std::cout << "mip " << mip << std::endl;
-    unsigned int mipWidth  = 128 * std::pow(0.5, mip);
-    unsigned int mipHeight = 128 * std::pow(0.5, mip);
+    unsigned int mipWidth  = (unsigned int)(128 * std::pow(0.5, mip));
+    unsigned int mipHeight = (unsigned int)(128 * std::pow(0.5, mip));
     glBindRenderbuffer(GL_RENDERBUFFER, mCaptureRBO);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, mipWidth, mipHeight);
     glViewport(0, 0, mipWidth, mipHeight);
@@ -165,7 +165,7 @@ void PBRApp::mainLoopBody() {
   glBindFramebuffer(GL_FRAMEBUFFER, 0);  
   glClearColor(0.05f, 0.1f, 0.1f, 1.0f);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  mProjection = glm::perspective(glm::radians(mCamera.Zoom),
+  mProjection = glm::perspective(glm::radians(mCamera.mZoom),
       (float)mWindowWidth / (float)mWindowHeight, 0.1f, 100.0f);
   mView = mCamera.GetViewMatrix();
 
@@ -174,7 +174,7 @@ void PBRApp::mainLoopBody() {
   mPBRShader.use();
   mPBRShader.setMat4("view", mView);
   mPBRShader.setMat4("projection", mProjection);
-  mPBRShader.setVec3("camPos", mCamera.Position);
+  mPBRShader.setVec3("camPos", mCamera.mPosition);
 
   mPBRShader.setInt("irradianceMap", 0);
   glActiveTexture(GL_TEXTURE0);

--- a/src/reflective_shadow_maps/reflective_shadow_maps.cpp
+++ b/src/reflective_shadow_maps/reflective_shadow_maps.cpp
@@ -204,7 +204,7 @@ void ReflectiveShadowMapsApp::mainLoopBody() {
       glm::vec3(0.0f, 1.0f, 0.0f));  
   mLightSpaceMatrix = lightProjection * lightView;
 
-  mProjection = glm::perspective(glm::radians(mCamera.Zoom),
+  mProjection = glm::perspective(glm::radians(mCamera.mZoom),
       (float)mWindowWidth / (float)mWindowHeight, 0.1f, 100.0f);
   mView = mCamera.GetViewMatrix();
 

--- a/src/shared/camera.cpp
+++ b/src/shared/camera.cpp
@@ -3,76 +3,76 @@
 #include "camera.hpp"
 #include <iostream>
 
-Camera::Camera(glm::vec3 position, glm::vec3 up, float yaw, float pitch) :
-  Front(glm::vec3(0.0f, 0.0f, -1.0f)),
-  MovementSpeed(SPEED), MouseSensitivity(SENSITIVTY), Zoom(ZOOM) {
-    Position = position;
-    WorldUp = up;
-    Yaw = yaw;
-    Pitch = pitch;
+Camera::Camera(glm::vec3 tPosition, glm::vec3 tUp, float tYaw, float tPitch) :
+  mFront(glm::vec3(0.0f, 0.0f, -1.0f)),
+  mMovementSpeed(SPEED), mMouseSensitivity(SENSITIVTY), mZoom(ZOOM) {
+    mPosition = tPosition;
+   mWorldUp = tUp;
+    mYaw = tYaw;
+    mPitch = tPitch;
     updateCameraVectors();
   }
 
-Camera::Camera(float posX, float posY, float posZ,
-    float upX, float upY, float upZ,
-    float yaw, float pitch) :
-  Front(glm::vec3(0.0f, 0.0f, -1.0f)),
-  MovementSpeed(SPEED), MouseSensitivity(SENSITIVTY), Zoom(ZOOM) {
-    Position = glm::vec3(posX, posY, posZ);
-    WorldUp = glm::vec3(upX, upY, upZ);
-    Yaw = yaw;
-    Pitch = pitch;
+Camera::Camera(float tPosX, float tPosY, float tPosZ,
+    float tUpX, float tUpY, float tUpZ,
+    float tYaw, float tPitch) :
+  mFront(glm::vec3(0.0f, 0.0f, -1.0f)),
+  mMovementSpeed(SPEED), mMouseSensitivity(SENSITIVTY), mZoom(ZOOM) {
+    mPosition = glm::vec3(tPosX, tPosY, tPosZ);
+    mWorldUp = glm::vec3(tUpX, tUpY, tUpZ);
+    mYaw = tYaw;
+    mPitch = tPitch;
     updateCameraVectors();
   }
 
 glm::mat4 Camera::GetViewMatrix() {
-  return glm::lookAt(Position, Position + Front, Up);
+  return glm::lookAt(mPosition, mPosition + mFront, mUp);
 }
 
-void Camera::ProcessKeyboard(Camera_Movement direction, float deltaTime) {
-  float velocity = MovementSpeed * deltaTime;
-  if (direction == FORWARD)
-    Position += Front * velocity;
-  if (direction == BACKWARD)
-    Position -= Front * velocity;
-  if (direction == LEFT)
-    Position -= Right * velocity;
-  if (direction == RIGHT)
-    Position += Right * velocity;
+void Camera::processKeyboard(Camera_Movement tDirection, float tDeltaTime) {
+  float velocity = mMovementSpeed * tDeltaTime;
+  if (tDirection == FORWARD)
+    mPosition += mFront * velocity;
+  if (tDirection == BACKWARD)
+    mPosition -= mFront * velocity;
+  if (tDirection == LEFT)
+    mPosition -= mRight * velocity;
+  if (tDirection == RIGHT)
+    mPosition += mRight * velocity;
 }
 
-void Camera::ProcessMouseMovement(float xoffset, float yoffset,
-    GLboolean constrainPitch) {
-  xoffset *= MouseSensitivity;
-  yoffset *= MouseSensitivity;
+void Camera::processMouseMovement(float tXoffset, float tYoffset,
+    GLboolean tConstrainPitch) {
+  tXoffset *= mMouseSensitivity;
+  tYoffset *= mMouseSensitivity;
 
-  Yaw += xoffset;
-  Pitch += yoffset;
+  mYaw += tXoffset;
+  mPitch += tYoffset;
 
-  if(constrainPitch) {
-    if(Pitch > 89.0f)
-      Pitch = 89.0f;
-    if(Pitch < -89.0f)
-      Pitch = -89.0f;
+  if(tConstrainPitch) {
+    if(mPitch > 89.0f)
+      mPitch = 89.0f;
+    if(mPitch < -89.0f)
+      mPitch = -89.0f;
   }
   updateCameraVectors();
 }
 
-void Camera::ProcessMouseScroll(float yoffset) {
-  if(Zoom >= 1.0f && Zoom <= 45.0f)
-    Zoom -= yoffset;
-  if(Zoom <= 1.0f)
-    Zoom = 1.0f;
-  if(Zoom >= 45.0f)
-    Zoom = 45.0f;
+void Camera::processMouseScroll(float tYoffset) {
+  if(mZoom >= 1.0f && mZoom <= 45.0f)
+    mZoom -= tYoffset;
+  if(mZoom <= 1.0f)
+    mZoom = 1.0f;
+  if(mZoom >= 45.0f)
+    mZoom = 45.0f;
 }
 
 void Camera::updateCameraVectors() {
-  glm::vec3 front;
-  front.x = cos(glm::radians(Yaw)) * cos(glm::radians(Pitch));
-  front.y = sin(glm::radians(Pitch));
-  front.z = sin(glm::radians(Yaw)) * cos(glm::radians(Pitch));
-  Front = glm::normalize(front);
-  Right = glm::normalize(glm::cross(Front, WorldUp));
-  Up = glm::normalize(glm::cross(Right, Front));
+  glm::dvec3 front;
+  front.x = cos(glm::radians(mYaw)) * cos(glm::radians(mPitch));
+  front.y = sin(glm::radians(mPitch));
+  front.z = sin(glm::radians(mYaw)) * cos(glm::radians(mPitch));
+  mFront = glm::normalize(front);
+  mRight = glm::normalize(glm::cross(mFront, mWorldUp));
+  mUp = glm::normalize(glm::cross(mRight, mFront));
 }

--- a/src/shared/camera.hpp
+++ b/src/shared/camera.hpp
@@ -18,16 +18,16 @@ const float ZOOM       =  45.0f;
 
 class Camera {
   public:
-    glm::vec3 Position;
-    glm::vec3 Front;
-    glm::vec3 Up;
-    glm::vec3 Right;
-    glm::vec3 WorldUp;
-    float Yaw;
-    float Pitch;
-    float MovementSpeed;
-    float MouseSensitivity;
-    float Zoom;
+    glm::vec3 mPosition;
+    glm::vec3 mFront;
+    glm::vec3 mUp;
+    glm::vec3 mRight;
+    glm::vec3 mWorldUp;
+    float mYaw;
+    float mPitch;
+    float mMovementSpeed;
+    float mMouseSensitivity;
+    float mZoom;
     Camera(glm::vec3 position = glm::vec3(0.0f, 0.0f, 0.0f),
         glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f),
         float yaw = YAW, float pitch = PITCH);
@@ -35,10 +35,10 @@ class Camera {
         float upX, float upY, float upZ,
         float yaw, float pitch);
     glm::mat4 GetViewMatrix();
-    void ProcessKeyboard(Camera_Movement direction, float deltaTime);
-    void ProcessMouseMovement(float xoffset, float yoffset,
+    void processKeyboard(Camera_Movement direction, float deltaTime);
+    void processMouseMovement(float xoffset, float yoffset,
         GLboolean constrainPitch = true);
-    void ProcessMouseScroll(float yoffset);
+    void processMouseScroll(float yoffset);
   private:
     void updateCameraVectors();
 };

--- a/src/shared/sphere.cpp
+++ b/src/shared/sphere.cpp
@@ -21,9 +21,10 @@ Sphere::Sphere(glm::mat4 tModel, glm::vec3 tColor) : mModel(tModel), mColor(tCol
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, mIndices.size() * sizeof(unsigned int),
         &mIndices[0], GL_STATIC_DRAW);
 
-    float stride = (3+3+2+3+3)*sizeof(float);
+    GLsizei stride = (3+3+2+3+3)*sizeof(float);
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, stride, (void*)0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 14 * sizeof(float), (void*)0);
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, stride, (void*)(3 * sizeof(float)));
     glEnableVertexAttribArray(2);
@@ -106,7 +107,7 @@ void Sphere::generateVertexes() {
   }
 
   std::vector<float> data;
-  for(int i = 0; i < positions.size(); ++i) {
+  for(unsigned int i = 0; i < positions.size(); ++i) {
     // stride = 14
     mVerts[i*14] = positions[i].x;
     mVerts[i*14+1] = positions[i].y;
@@ -144,7 +145,7 @@ void Sphere::render(Shader* tShader) {
 
   auto sphereIndexCount = mIndices.size();
   glBindVertexArray(mVAO);
-  glDrawElements(GL_TRIANGLE_STRIP, sphereIndexCount, GL_UNSIGNED_INT, 0);
+  glDrawElements(GL_TRIANGLE_STRIP, (int)sphereIndexCount, GL_UNSIGNED_INT, 0);
 
   glBindVertexArray(0);
 }

--- a/src/shared/textures.cpp
+++ b/src/shared/textures.cpp
@@ -7,7 +7,7 @@
 #include "stb_image.h"
 
 unsigned int loadTextureF(const std::string& tPath) {
-  loadTextureF(tPath.c_str());
+  return loadTextureF(tPath.c_str());
 }
 
 unsigned int loadTextureF(char const * tPath) {
@@ -45,7 +45,7 @@ unsigned int loadTextureF(char const * tPath) {
 }
 
 unsigned int loadTexture(const std::string& tPath) {
-  loadTexture(tPath.c_str());
+  return loadTexture(tPath.c_str());
 }
 
 unsigned int loadTexture(char const * tPath) {

--- a/src/ssao/ssao.cpp
+++ b/src/ssao/ssao.cpp
@@ -141,7 +141,7 @@ void SSAOApp::initRandomizedLookupHemisphere() {
 
 void SSAOApp::mainLoopBody() {
   glClearColor(0.05f, 0.1f, 0.1f, 1.0f);
-  mProjection = glm::perspective(glm::radians(mCamera.Zoom),
+  mProjection = glm::perspective(glm::radians(mCamera.mZoom),
       (float)mWindowWidth / (float)mWindowHeight, 0.1f, 100.0f);
   mView = mCamera.GetViewMatrix();
 


### PR DESCRIPTION
- use "m" "t" prefixes for vars in camera object
- fix various compiler warnings